### PR TITLE
Make master sword invisible and fix ms flag

### DIFF
--- a/soh/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
+++ b/soh/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
@@ -205,6 +205,11 @@ void BgTokiSwd_Draw(Actor* thisx, PlayState* play2) {
     BgTokiSwd* this = (BgTokiSwd*)thisx;
     s32 pad[3];
 
+    // Do not draw the Master Sword in the pedestal if the player has not found it yet
+    if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_MASTER_SWORD) && !CHECK_OWNED_EQUIP(EQUIP_SWORD, 1)) {
+        return;
+    }
+
     OPEN_DISPS(play->state.gfxCtx);
 
     Gfx_SetupDL_25Opa(play->state.gfxCtx);


### PR DESCRIPTION
This makes the Master Sword invisible in the Ganon fight and in the Temple of Time pedestal when the player hasn't found the master sword yet.

Also fixes the assignment of the ms flag in the Ganon fight as static declaration only assign once, so previously once the ms flag was set to 1, it would stay as 1 forever until you close SoH entirely. Now it always assigns it to 1 on init (default) and only if you dont have the master sword in inventory with ms shuffle on will it set the ms flag to 0 for later use.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/stratomaster64/Shipwright/actions/artifacts/957260823.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/stratomaster64/Shipwright/actions/artifacts/957260824.zip)
  - [soh-linux-performance.zip](https://nightly.link/stratomaster64/Shipwright/actions/artifacts/957260825.zip)
  - [soh-mac.zip](https://nightly.link/stratomaster64/Shipwright/actions/artifacts/957260826.zip)
  - [soh-switch.zip](https://nightly.link/stratomaster64/Shipwright/actions/artifacts/957260828.zip)
  - [soh-wiiu.zip](https://nightly.link/stratomaster64/Shipwright/actions/artifacts/957260829.zip)
  - [soh-windows.zip](https://nightly.link/stratomaster64/Shipwright/actions/artifacts/957260830.zip)
<!--- section:artifacts:end -->