### PR TITLE
Better swordless handling with temp B

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -2449,12 +2449,17 @@ void Heaps_Free(void);
 
 CollisionHeader* BgCheck_GetCollisionHeader(CollisionContext* colCtx, s32 bgId);
 
-void Interface_CreateQuadVertexGroup(Vtx* vtxList, s32 xStart, s32 yStart, s32 width, s32 height, u8 flippedH);
-
 // Exposing these methods to leverage them from the file select screen to render messages
 void Message_OpenText(PlayState* play, u16 textId);
 void Message_Decode(PlayState* play);
 void Message_DrawText(PlayState* play, Gfx** gfxP);
+
+// #region SOH [General]
+
+void Interface_CreateQuadVertexGroup(Vtx* vtxList, s32 xStart, s32 yStart, s32 width, s32 height, u8 flippedH);
+void Interface_RandoRestoreSwordless(void);
+
+// #endregion
 
 #ifdef __cplusplus
 #undef this

--- a/soh/include/z64save.h
+++ b/soh/include/z64save.h
@@ -289,7 +289,6 @@ typedef struct {
     /*        */ u8 mqDungeonCount;
     /*        */ u8 pendingIceTrapCount;
     /*        */ SohStats sohStats;
-    /*        */ u8 temporaryWeapon;
     /*        */ FaroresWindData backupFW;
     /*        */ RandomizerCheckTrackerData checkTrackerData[RC_MAX];
     // #endregion

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -249,6 +249,7 @@ void AutoSave(GetItemEntry itemEntry) {
     // Don't autosave in the Chamber of Sages since resuming from that map breaks the game
     // Don't autosave during the Ganon fight when picking up the Master Sword
     // Don't autosave in the fishing pond to prevent getting rod on B outside of the pond
+    // Don't autosave in the bombchu bowling alley to prevent having chus on B outside of the minigame
     // Don't autosave in grottos since resuming from grottos breaks the game.
     if ((CVarGetInteger("gAutosave", AUTOSAVE_OFF) != AUTOSAVE_OFF) && (gPlayState != NULL) && (gSaveContext.pendingSale == ITEM_NONE) &&
         (gPlayState->gameplayFrames > 60 && gSaveContext.cutsceneIndex < 0xFFF0) && (gPlayState->sceneNum != SCENE_GANON_BOSS)) {
@@ -313,7 +314,8 @@ void AutoSave(GetItemEntry itemEntry) {
             performSave = true;
         }
         if (gPlayState->sceneNum == SCENE_FAIRYS_FOUNTAIN || gPlayState->sceneNum == SCENE_GROTTOS ||
-            gPlayState->sceneNum == SCENE_CHAMBER_OF_THE_SAGES || gPlayState->sceneNum == SCENE_FISHING_POND) {
+            gPlayState->sceneNum == SCENE_CHAMBER_OF_THE_SAGES || gPlayState->sceneNum == SCENE_FISHING_POND ||
+            gPlayState->sceneNum == SCENE_BOMBCHU_BOWLING_ALLEY) {
             if (CVarGetInteger("gAutosave", AUTOSAVE_OFF) == AUTOSAVE_LOCATION_AND_MAJOR_ITEMS ||
                 CVarGetInteger("gAutosave", AUTOSAVE_OFF) == AUTOSAVE_LOCATION_AND_ALL_ITEMS ||
                 CVarGetInteger("gAutosave", AUTOSAVE_OFF) == AUTOSAVE_LOCATION) {

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -248,6 +248,7 @@ void AutoSave(GetItemEntry itemEntry) {
     // Don't autosave immediately after buying items from shops to prevent getting them for free!
     // Don't autosave in the Chamber of Sages since resuming from that map breaks the game
     // Don't autosave during the Ganon fight when picking up the Master Sword
+    // Don't autosave in the fishing pond to prevent getting rod on B outside of the pond
     // Don't autosave in grottos since resuming from grottos breaks the game.
     if ((CVarGetInteger("gAutosave", AUTOSAVE_OFF) != AUTOSAVE_OFF) && (gPlayState != NULL) && (gSaveContext.pendingSale == ITEM_NONE) &&
         (gPlayState->gameplayFrames > 60 && gSaveContext.cutsceneIndex < 0xFFF0) && (gPlayState->sceneNum != SCENE_GANON_BOSS)) {
@@ -311,8 +312,8 @@ void AutoSave(GetItemEntry itemEntry) {
                    CVarGetInteger("gAutosave", AUTOSAVE_OFF) == AUTOSAVE_LOCATION) {
             performSave = true;
         }
-        if ((gPlayState->sceneNum == SCENE_FAIRYS_FOUNTAIN) || (gPlayState->sceneNum == SCENE_GROTTOS) ||
-                (gPlayState->sceneNum == SCENE_CHAMBER_OF_THE_SAGES)) {
+        if (gPlayState->sceneNum == SCENE_FAIRYS_FOUNTAIN || gPlayState->sceneNum == SCENE_GROTTOS ||
+            gPlayState->sceneNum == SCENE_CHAMBER_OF_THE_SAGES || gPlayState->sceneNum == SCENE_FISHING_POND) {
             if (CVarGetInteger("gAutosave", AUTOSAVE_OFF) == AUTOSAVE_LOCATION_AND_MAJOR_ITEMS ||
                 CVarGetInteger("gAutosave", AUTOSAVE_OFF) == AUTOSAVE_LOCATION_AND_ALL_ITEMS ||
                 CVarGetInteger("gAutosave", AUTOSAVE_OFF) == AUTOSAVE_LOCATION) {

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -567,6 +567,7 @@ void Entrance_HandleEponaState(void) {
         player->actor.parent = NULL;
         AREG(6) = 0;
         gSaveContext.equips.buttonItems[0] = gSaveContext.buttonStatus[0]; //"temp B"
+        Interface_RandoRestoreSwordless();
     }
 }
 

--- a/soh/src/code/z_game_over.c
+++ b/soh/src/code/z_game_over.c
@@ -57,6 +57,7 @@ void GameOver_Update(PlayState* play) {
 
                 if (gSaveContext.buttonStatus[0] != BTN_ENABLED) {
                     gSaveContext.equips.buttonItems[0] = gSaveContext.buttonStatus[0];
+                    Interface_RandoRestoreSwordless();
                 } else {
                     gSaveContext.equips.buttonItems[0] = ITEM_NONE;
                 }

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -2328,17 +2328,8 @@ void Play_PerformSave(PlayState* play) {
     if (play != NULL && gSaveContext.fileNum != 0xFF) {
         Play_SaveSceneFlags(play);
         gSaveContext.savedSceneNum = play->sceneNum;
-        if (gSaveContext.temporaryWeapon) {
-            gSaveContext.equips.buttonItems[0] = ITEM_NONE;
-            GET_PLAYER(play)->currentSwordItemId = ITEM_NONE;
-            Inventory_ChangeEquipment(EQUIP_SWORD, PLAYER_SWORD_NONE);
-            Save_SaveFile();
-            gSaveContext.equips.buttonItems[0] = ITEM_SWORD_KOKIRI;
-            GET_PLAYER(play)->currentSwordItemId = ITEM_SWORD_KOKIRI;
-            Inventory_ChangeEquipment(EQUIP_SWORD, PLAYER_SWORD_KOKIRI);
-        } else {
-            Save_SaveFile();
-        }
+        Save_SaveFile();
+
         uint8_t triforceHuntCompleted =
             IS_RANDO &&
             gSaveContext.triforcePiecesCollected == Randomizer_GetSettingValue(RSK_TRIFORCE_HUNT_PIECES_REQUIRED) &&

--- a/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -5125,16 +5125,6 @@ void Fishing_HandleOwnerDialog(Fishing* this, PlayState* play) {
 
             if (Message_GetState(&play->msgCtx) == TEXT_STATE_NONE) {
                 this->unk_15C = 0;
-
-                Player* player = GET_PLAYER(play);
-
-                if (gSaveContext.temporaryWeapon) {
-                    player->currentSwordItemId = ITEM_NONE;
-                    gSaveContext.equips.buttonItems[0] = ITEM_NONE;
-                    Inventory_ChangeEquipment(EQUIP_SWORD, PLAYER_SWORD_NONE);
-                    gSaveContext.temporaryWeapon = false;
-                }
-
                 if (D_80B7A68C != 0) {
                     D_80B7A688 = 1;
                     D_80B7A68C = 0;

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -15125,17 +15125,6 @@ s32 Player_IsDroppingFish(PlayState* play) {
 s32 Player_StartFishing(PlayState* play) {
     Player* this = GET_PLAYER(play);
 
-    if (gSaveContext.linkAge == 1) {
-        if (!CHECK_OWNED_EQUIP(EQUIP_SWORD, 0)) {
-            gSaveContext.temporaryWeapon = true;
-        }
-        if (this->heldItemId == ITEM_NONE) {
-            this->currentSwordItemId = ITEM_SWORD_KOKIRI;
-            gSaveContext.equips.buttonItems[0] = ITEM_SWORD_KOKIRI;
-            Inventory_ChangeEquipment(EQUIP_SWORD, PLAYER_SWORD_KOKIRI);
-        }
-    }
-
     func_80832564(play, this);
     func_80835F44(play, this, ITEM_FISHING_POLE);
     return 1;

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -4251,6 +4251,9 @@ void KaleidoScope_Update(PlayState* play)
                 gSaveContext.buttonStatus[buttonIndex] = sButtonStatusSave[buttonIndex];
             }
 
+            // Used to clear swordless temp B after unpause so minigame/epona handling restarts
+            Interface_RandoRestoreSwordless();
+
             interfaceCtx->unk_1FA = interfaceCtx->unk_1FC = 0;
             osSyncPrintf(VT_FGCOL(YELLOW));
             osSyncPrintf("i=%d  LAST_TIME_TYPE=%d\n", i, gSaveContext.unk_13EE);


### PR DESCRIPTION
This PR aims to improve swordless state handling during minigames/epona by hijacking tempB with a "marker" value to allow us to restore the B button as empty without "disabling" the B button in the HUD. This should resolve all remaining issues with the HUD.
This also resolves child not having slingshot on B during child archery when swordless.

Additionally, an old swordless hack for child fishing can be removed in favor of the new handling, which should remove any possible cases that a kokiri sword is accidentally given to the player. This required preventing auto save in the fishing pond to avoid the fishing rod on B being saved to file.

A similar auto save restriction for bombchu bowling was needed. Shooting gallery did not have issues with auto save though.

The following scenarios have been tested:
* Riding Epona without a sword or bow
* Riding Epona with a sword but no bow
* Riding Epona without a sword but with a bow
* Pausing while on Epona
* Saving while on Epona
* Fishing as child or adult without a sword
* Pausing while fishing
* Saving while fishing
* Game over while fishing
* Playing shooting gallery as child or adult without a sword
* Game over during shooting gallery
* Playing bombchu bowling without a sword
* Game over during bomchu bowling

Behind the scenes, rather than storing `ITEM_NONE` which is the same as `BTN_DISABLED` (255), I've elected to store `ITEM_NONE_FE` (254) so that we have a marker to know that we were swordless before and it doesn't dim/disabled the B button like (255) does.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/stratomaster64/Shipwright/actions/artifacts/983936060.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/stratomaster64/Shipwright/actions/artifacts/983936061.zip)
  - [soh-linux-performance.zip](https://nightly.link/stratomaster64/Shipwright/actions/artifacts/983936062.zip)
  - [soh-mac.zip](https://nightly.link/stratomaster64/Shipwright/actions/artifacts/983936064.zip)
  - [soh-switch.zip](https://nightly.link/stratomaster64/Shipwright/actions/artifacts/983936065.zip)
  - [soh-wiiu.zip](https://nightly.link/stratomaster64/Shipwright/actions/artifacts/983936066.zip)
  - [soh-windows.zip](https://nightly.link/stratomaster64/Shipwright/actions/artifacts/983936067.zip)
<!--- section:artifacts:end -->